### PR TITLE
release ビルド用の改修

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,6 +26,13 @@ android {
         pickFirst 'META-INF/LICENSE.txt'
         pickFirst 'LICENSE.txt'
     }
+
+    lintOptions {
+        checkReleaseBuilds false
+        // Or, if you prefer, you can continue to check for errors in release builds,
+        // but continue the build even when errors are found:
+        abortOnError false
+    }
 }
 
 repositories {


### PR DESCRIPTION
リリースビルド時に Xlint を実行しないよう修正
http://stackoverflow.com/questions/24098494/error-when-generate-signed-apk
