### PR TITLE
アラーム更新画面

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     compile 'de.devland.esperandro:esperandro-api:2.2.0'
     apt 'de.devland.esperandro:esperandro:2.2.0'
     compile 'de.devland.esperandro:esperandro-jackson-addon:2.2.0'
+    compile 'net.danlew:android.joda:2.6.0'
 
     // DeployGate SDK for Android
     compile 'com.deploygate:sdk:3.1'

--- a/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmRegisterActivityTest.java
+++ b/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmRegisterActivityTest.java
@@ -20,12 +20,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import de.devland.esperandro.Esperandro;
 
-import static com.team7.wakeuptaroapp.assertions.AlarmAssertion.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -35,6 +34,8 @@ import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.team7.wakeuptaroapp.assertions.AlarmAssertion.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -50,7 +51,7 @@ import static org.hamcrest.core.Is.is;
 public class AlarmRegisterActivityTest {
 
     @Rule
-    public ActivityTestRule<AlarmRegisterActivity> alarmActivityRule = new ActivityTestRule<>(AlarmRegisterActivity.class);
+    public ActivityTestRule<AlarmListActivity> alarmActivityRule = new ActivityTestRule<>(AlarmListActivity.class);
 
     private TaroSharedPreference preference;
 
@@ -58,6 +59,11 @@ public class AlarmRegisterActivityTest {
     public void setUp() {
         preference = Esperandro.getPreferences(TaroSharedPreference.class,
                 alarmActivityRule.getActivity().getApplicationContext());
+        preference.alarms(new ArrayList<Alarm>());
+
+        // 登録画面へ
+        onView(withId(R.id.new_alarm)).perform(click());
+        onView(withClassName(is("AlarmRegisterActivity")));
     }
 
     @After
@@ -121,7 +127,7 @@ public class AlarmRegisterActivityTest {
 
     @Test
     public void 登録したアラーム情報が_SharedPreference_に保存されていること() {
-        assertThat(preference.alarms()).isNull();
+        assertThat(preference.alarms()).isEmpty();
 
         // 登録内容を設定
         selectTime();
@@ -138,6 +144,9 @@ public class AlarmRegisterActivityTest {
         List<Alarm> storedAlarms = preference.alarms();
         assertThat(storedAlarms).hasSize(1);
         assertThat(storedAlarms.get(0)).hasTime("13:51").hasDayOfWeeks("6_sat", "7_sun");
+
+        // 一覧画面へ戻ってくること
+        onView(withClassName(is("AlarmListActivity")));
     }
 
     private void selectTime() {

--- a/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmRegisterActivityTest.java
+++ b/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmRegisterActivityTest.java
@@ -41,16 +41,16 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.Is.is;
 
 /**
- * {@link AlarmActivity}に対するテストクラス。<br />
+ * {@link AlarmRegisterActivity}に対するテストクラス。<br />
  * テスト実行にはエミュレータ、もしくは接続された実機経由で行う必要がある。
  *
  * @author Naotake.K
  */
 @RunWith(AndroidJUnit4.class)
-public class AlarmActivityTest {
+public class AlarmRegisterActivityTest {
 
     @Rule
-    public ActivityTestRule<AlarmActivity> alarmActivityRule = new ActivityTestRule<>(AlarmActivity.class);
+    public ActivityTestRule<AlarmRegisterActivity> alarmActivityRule = new ActivityTestRule<>(AlarmRegisterActivity.class);
 
     private TaroSharedPreference preference;
 

--- a/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivityTest.java
+++ b/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivityTest.java
@@ -1,0 +1,97 @@
+package com.team7.wakeuptaroapp.activities;
+
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.widget.TimePicker;
+
+import com.team7.wakeuptaroapp.R;
+import com.team7.wakeuptaroapp.models.Alarm;
+import com.team7.wakeuptaroapp.utils.TaroSharedPreference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+
+import de.devland.esperandro.Esperandro;
+
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.team7.wakeuptaroapp.activities.AlarmRegisterActivityTest.setTime;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * {@link AlarmUpdateActivity}に対するテストクラス。<br />
+ * テスト実行にはエミュレータ、もしくは接続された実機経由で行う必要がある。
+ *
+ * @author Naotake.K
+ */
+@RunWith(AndroidJUnit4.class)
+public class AlarmUpdateActivityTest {
+
+    @Rule
+    public ActivityTestRule<AlarmListActivity> alarmActivityRule = new ActivityTestRule<AlarmListActivity>(AlarmListActivity.class);
+
+    private static final Long DUMMY_KEY = 1234567890L;
+
+    private TaroSharedPreference preference;
+
+    @Before
+    public void setUp() {
+        preference = Esperandro.getPreferences(TaroSharedPreference.class,
+                alarmActivityRule.getActivity().getApplicationContext());
+        preference.alarms(new ArrayList<Alarm>());
+    }
+
+    @After
+    public void tearDown() {
+        preference.clear();
+    }
+
+    @Test
+    public void 登録画面が入力した内容が更新画面に表示されていること() {
+        onView(withClassName(is("AlarmListActivity")));
+
+        // 登録画面へ
+        onView(withId(R.id.new_alarm)).perform(click());
+        onView(withClassName(is("AlarmRegisterActivity")));
+
+        // 時刻を選択
+        onData(withKey("alarmTime")).perform(click());
+        onView(withClassName(equalTo(TimePicker.class.getName()))).perform(setTime(13, 51));
+        onView(withText("Set")).perform(click());
+
+        // 曜日を選択
+        onData(withKey("alarmDayOfWeeks")).perform(click());
+        onView(withText("水")).perform(click());
+        onView(withText("OK")).perform(click());
+
+        // 登録
+        onView(withId(R.id.action_store_alarm)).perform(click());
+
+        // 一覧画面へ
+        onView(withClassName(is("AlarmListActivity")));
+
+        // 更新画面へ
+        onView(withId(R.id.edit_alarm)).perform(click()); // TODO 仮実装
+        onView(withClassName(is("AlarmUpdateActivity")));
+
+        // 検証
+        onData(withKey("alarmTime")).onChildView(
+                withId(android.R.id.summary)).check(matches(withText("13:51")));
+        onData(withKey("alarmDayOfWeeks")).onChildView(
+                withId(android.R.id.summary)).check(matches(withText("水")));
+        onData(withKey("alarmRingtone")).onChildView(
+                withId(android.R.id.summary)).check(matches(withText("サイレント")));
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.team7.wakeuptaroapp"
-          xmlns:android="http://schemas.android.com/apk/res/android"
-          android:versionCode="@integer/version_code"
-          android:versionName="@string/version_name">
+<manifest
+    package="com.team7.wakeuptaroapp"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    >
 
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
@@ -21,6 +21,7 @@
             android:theme="@android:style/Theme.Light.NoTitleBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
+
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
@@ -29,8 +30,12 @@
             android:label="@string/title_activity_alarm_list">
         </activity>
         <activity
-            android:name=".activities.AlarmActivity"
-            android:label="@string/title_activity_alarm">
+            android:name=".activities.AlarmRegisterActivity"
+            android:label="@string/title_activity_alarm_register">
+        </activity>
+        <activity
+            android:name=".activities.AlarmUpdateActivity"
+            android:label="@string/title_activity_alarm_update">
         </activity>
         <activity
             android:name=".activities.SettingActivity"

--- a/app/src/main/java/com/team7/wakeuptaroapp/App.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/App.java
@@ -3,6 +3,12 @@ package com.team7.wakeuptaroapp;
 import android.app.Application;
 
 import com.deploygate.sdk.DeployGate;
+import com.team7.wakeuptaroapp.models.Alarm;
+import com.team7.wakeuptaroapp.utils.TaroSharedPreference;
+
+import net.danlew.android.joda.JodaTimeAndroid;
+
+import java.util.ArrayList;
 
 import de.devland.esperandro.Esperandro;
 import de.devland.esperandro.serialization.JacksonSerializer;
@@ -18,6 +24,13 @@ public class App extends Application {
     public void onCreate() {
         super.onCreate();
         DeployGate.install(this);
+        JodaTimeAndroid.init(this);
         Esperandro.setSerializer(new JacksonSerializer());
+
+        // アラーム一覧の NULL チェックを意識しないで済むように初期化
+        TaroSharedPreference preference = Esperandro.getPreferences(TaroSharedPreference.class, this);
+        if (preference.alarms() == null) {
+            preference.alarms(new ArrayList<Alarm>());
+        }
     }
 }

--- a/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmListActivity.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmListActivity.java
@@ -9,6 +9,9 @@ import android.view.View;
 
 import com.team7.wakeuptaroapp.R;
 import com.team7.wakeuptaroapp.utils.AppLog;
+import com.team7.wakeuptaroapp.utils.TaroSharedPreference;
+
+import de.devland.esperandro.Esperandro;
 
 /**
  * アラーム一覧画面に対するアクティビティ。<br />
@@ -38,7 +41,21 @@ public class AlarmListActivity extends AppCompatActivity {
         AppLog.d("onClickNewAlarm");
 
         // アラーム登録 Activity 呼び出し
-        Intent intent = new Intent(AlarmListActivity.this, AlarmActivity.class);
+        Intent intent = new Intent(AlarmListActivity.this, AlarmRegisterActivity.class);
+        startActivity(intent);
+    }
+
+    /**
+     * アラーム編集ボタンが押下されたときの振る舞いを定義する。
+     */
+    public void onClickEditAlarm(View view) {
+        AppLog.d("onClickEditAlarm");
+
+        TaroSharedPreference preference =
+                Esperandro.getPreferences(TaroSharedPreference.class, getApplicationContext());
+
+        Intent intent = new Intent(AlarmListActivity.this, AlarmUpdateActivity.class);
+        intent.putExtra(AlarmUpdateActivity.ALARM_KEY, preference.alarms().get(0).getAlarmKey());
         startActivity(intent);
     }
 

--- a/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmListActivity.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmListActivity.java
@@ -54,6 +54,7 @@ public class AlarmListActivity extends AppCompatActivity {
         TaroSharedPreference preference =
                 Esperandro.getPreferences(TaroSharedPreference.class, getApplicationContext());
 
+        // FIXME 仮実装
         Intent intent = new Intent(AlarmListActivity.this, AlarmUpdateActivity.class);
         intent.putExtra(AlarmUpdateActivity.ALARM_KEY, preference.alarms().get(0).getAlarmKey());
         startActivity(intent);

--- a/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmRegisterActivity.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmRegisterActivity.java
@@ -13,7 +13,7 @@ import com.team7.wakeuptaroapp.utils.TaroAlarmManager;
 import com.team7.wakeuptaroapp.utils.TaroSharedPreference;
 import com.team7.wakeuptaroapp.utils.Toasts;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import de.devland.esperandro.Esperandro;
@@ -100,12 +100,9 @@ public class AlarmRegisterActivity extends AppCompatActivity {
         AppLog.d("Alarm Week: " + dayOfWeeks);
         AppLog.d("Alarm Ring: " + ringtoneUri);
 
-        ArrayList<Alarm> alarms = preference.alarms();
-        if (alarms == null) {
-            alarms = new ArrayList<>();
-        }
-
         Alarm newAlarm = new Alarm(time, dayOfWeeks, ringtoneUri);
+
+        List<Alarm> alarms = preference.alarms();
         alarms.add(newAlarm);
         preference.alarms(alarms);
 

--- a/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmRegisterActivity.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmRegisterActivity.java
@@ -1,0 +1,122 @@
+package com.team7.wakeuptaroapp.activities;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import com.team7.wakeuptaroapp.R;
+import com.team7.wakeuptaroapp.fragments.AlarmFragment;
+import com.team7.wakeuptaroapp.models.Alarm;
+import com.team7.wakeuptaroapp.utils.AppLog;
+import com.team7.wakeuptaroapp.utils.TaroAlarmManager;
+import com.team7.wakeuptaroapp.utils.TaroSharedPreference;
+import com.team7.wakeuptaroapp.utils.Toasts;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+import de.devland.esperandro.Esperandro;
+
+/**
+ * アラーム登録画面に対するアクティビティ。
+ *
+ * @author Naotake.K
+ */
+public class AlarmRegisterActivity extends AppCompatActivity {
+
+    // SharedPreference
+    private TaroSharedPreference preference;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // 登録項目をバインド
+        getFragmentManager().beginTransaction()
+                .replace(android.R.id.content, new AlarmFragment())
+                .commit();
+
+        // 戻る
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        // SharedPreference
+        preference = Esperandro.getPreferences(TaroSharedPreference.class, getApplicationContext());
+        preference.alarmTime(null);
+        preference.alarmDayOfWeeks(null);
+        preference.alarmRingtone(null);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_alarm_register, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Handle action bar item clicks here. The action bar will
+        // automatically handle clicks on the Home/Up button, so long
+        // as you specify a parent activity in AndroidManifest.xml.
+        int id = item.getItemId();
+
+        // 登録ボタン押下
+        if (id == R.id.action_store_alarm) {
+            AppLog.d("Tap to store on alarm.");
+
+            // アラームの保存
+            Alarm newAlarm = storeAlarm();
+            registerAlarm(newAlarm);
+
+            // メッセージ
+            Toasts.showMessageLong(this, R.string.message_store_alarm);
+
+            finish();
+            return true;
+        }
+
+        // 戻るボタン押下
+        if (id == android.R.id.home) {
+            AppLog.d("Tap to back on alarm.");
+
+            finish();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    /**
+     * 入力内容を基にアラーム情報を SharedPreference に保存する。
+     */
+    private Alarm storeAlarm() {
+
+        String time = preference.alarmTime();
+        Set<String> dayOfWeeks = preference.alarmDayOfWeeks();
+        String ringtoneUri = preference.alarmRingtone();
+
+        AppLog.d("Alarm Time: " + time);
+        AppLog.d("Alarm Week: " + dayOfWeeks);
+        AppLog.d("Alarm Ring: " + ringtoneUri);
+
+        ArrayList<Alarm> alarms = preference.alarms();
+        if (alarms == null) {
+            alarms = new ArrayList<>();
+        }
+
+        Alarm newAlarm = new Alarm(time, dayOfWeeks, ringtoneUri);
+        alarms.add(newAlarm);
+        preference.alarms(alarms);
+
+        return newAlarm;
+    }
+
+    /**
+     * 入力内容を基にアラーム情報を登録する。
+     */
+    private void registerAlarm(Alarm alarm) {
+        TaroAlarmManager alarmManager = new TaroAlarmManager(getApplicationContext());
+        alarmManager.register(alarm);
+    }
+}

--- a/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivity.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivity.java
@@ -14,7 +14,6 @@ import com.team7.wakeuptaroapp.utils.TaroAlarmManager;
 import com.team7.wakeuptaroapp.utils.TaroSharedPreference;
 import com.team7.wakeuptaroapp.utils.Toasts;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -59,7 +58,7 @@ public class AlarmUpdateActivity extends AppCompatActivity {
         Preconditions.checkArgument((targetAlarmKey != 0), "Illegal Update Alarm Key");
 
         targetAlarm = selectAlarm(preference.alarms());
-        Preconditions.notNull(targetAlarm, "Not Exists Update Alarm " + targetAlarmKey);
+        Preconditions.notNull(targetAlarm, "Not Exists Update Alarm(onCreate) " + targetAlarmKey);
 
         preference.alarmTime(targetAlarm.getTime());
         preference.alarmDayOfWeeks(targetAlarm.getDayOfWeeks());
@@ -121,10 +120,8 @@ public class AlarmUpdateActivity extends AppCompatActivity {
         AppLog.d("Alarm Week: " + dayOfWeeks);
         AppLog.d("Alarm Ring: " + ringtoneUri);
 
-        ArrayList<Alarm> alarms = preference.alarms();
-        if (alarms == null) {
-            alarms = new ArrayList<>();
-        }
+        List<Alarm> alarms = preference.alarms();
+        Preconditions.notNull(targetAlarm, "Not Exists Update Alarm " + targetAlarmKey);
 
         targetAlarm.setTime(time);
         targetAlarm.setDayOfWeeks(dayOfWeeks);
@@ -143,9 +140,7 @@ public class AlarmUpdateActivity extends AppCompatActivity {
      * @return キーが一致したアラーム情報
      */
     private Alarm selectAlarm(List<Alarm> alarms) {
-        if (alarms == null) {
-            return null;
-        }
+        Preconditions.notNull(alarms, "Not Exists Alarms " + targetAlarmKey);
 
         for (Alarm alarm : alarms) {
             if (alarm.equalsKey(targetAlarmKey)) {

--- a/app/src/main/java/com/team7/wakeuptaroapp/fragments/AlarmFragment.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/fragments/AlarmFragment.java
@@ -1,0 +1,20 @@
+package com.team7.wakeuptaroapp.fragments;
+
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+
+import com.team7.wakeuptaroapp.R;
+
+/**
+ * アラームの登録 / 更新の項目を扱うフラグメント。
+ *
+ * @author Naotake.K
+ */
+public class AlarmFragment extends PreferenceFragment {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.alarm_settings);
+    }
+}

--- a/app/src/main/java/com/team7/wakeuptaroapp/models/Alarm.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/models/Alarm.java
@@ -6,9 +6,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.team7.wakeuptaroapp.utils.Alarms;
 
+import org.joda.time.LocalDateTime;
+
 import java.io.Serializable;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -55,7 +56,7 @@ public class Alarm implements Comparable<Alarm>, Serializable {
         this.dayOfWeeks = dayOfWeeks;
         this.ringtoneUri = ringtoneUri;
         this.valid = false;
-        this.registeredDateTime = Long.valueOf(new Date().getTime());
+        this.registeredDateTime = LocalDateTime.now().toDateTime().getMillis();
     }
 
     /**

--- a/app/src/main/java/com/team7/wakeuptaroapp/models/Alarm.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/models/Alarm.java
@@ -100,14 +100,16 @@ public class Alarm implements Comparable<Alarm>, Serializable {
      * 曜日一覧を取得する。<br />
      * 未設定の場合、空の一覧 ({@link Collections#EMPTY_SET}) を返す。
      *
-     * @return アラーム一覧
+     * @return アラームの曜日一覧
      */
     public Set<String> getDayOfWeeks() {
         return (dayOfWeeks == null ? Collections.EMPTY_SET : dayOfWeeks);
     }
 
     /**
-     * @deprecated この Setter は Esperandro 向けに用意しているため、通常のアプリケーションでの使用不可
+     * 曜日一覧を設定する。
+     *
+     * @param dayOfWeeks アラームの曜日一覧
      */
     public void setDayOfWeeks(Set<String> dayOfWeeks) {
         this.dayOfWeeks = dayOfWeeks;
@@ -123,7 +125,9 @@ public class Alarm implements Comparable<Alarm>, Serializable {
     }
 
     /**
-     * @deprecated この Setter は Esperandro 向けに用意しているため、通常のアプリケーションでの使用不可
+     * アラーム音の URI (文字列) を取得する。
+     *
+     * @param ringtoneUri アラーム音の URI (文字列)
      */
     public void setRingtoneUri(String ringtoneUri) {
         this.ringtoneUri = ringtoneUri;
@@ -171,6 +175,17 @@ public class Alarm implements Comparable<Alarm>, Serializable {
     @JsonIgnore
     public Long getAlarmKey() {
         return registeredDateTime;
+    }
+
+    /**
+     * このアラームが指定されたキー情報と等しいかどうかを判定する。
+     *
+     * @param key 判定対象となるキー情報
+     * @return 等しい場合は true
+     */
+    @JsonIgnore
+    public boolean equalsKey(Long key) {
+        return (registeredDateTime.equals(key));
     }
 
     @Override

--- a/app/src/main/java/com/team7/wakeuptaroapp/models/DayOfWeek.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/models/DayOfWeek.java
@@ -18,7 +18,7 @@ public enum DayOfWeek {
     /**
      * 火曜日
      */
-    TUESDAY(Calendar.TUESDAY, "2_tue</", R.string.label_alarm_tue),
+    TUESDAY(Calendar.TUESDAY, "2_tue", R.string.label_alarm_tue),
     /**
      * 水曜日
      */

--- a/app/src/main/java/com/team7/wakeuptaroapp/models/DayOfWeek.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/models/DayOfWeek.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 
 import com.team7.wakeuptaroapp.R;
 
-import java.util.Calendar;
+import org.joda.time.DateTimeConstants;
 
 /**
  * @author Naotake.K
@@ -14,50 +14,49 @@ public enum DayOfWeek {
     /**
      * 月曜日
      */
-    MONDAY(Calendar.MONDAY, "1_mon", R.string.label_alarm_mon),
+    MONDAY(DateTimeConstants.MONDAY, "1_mon", R.string.label_alarm_mon),
     /**
      * 火曜日
      */
-    TUESDAY(Calendar.TUESDAY, "2_tue", R.string.label_alarm_tue),
+    TUESDAY(DateTimeConstants.TUESDAY, "2_tue", R.string.label_alarm_tue),
     /**
      * 水曜日
      */
-    WEDNESDAY(Calendar.WEDNESDAY, "3_wed", R.string.label_alarm_wed),
+    WEDNESDAY(DateTimeConstants.WEDNESDAY, "3_wed", R.string.label_alarm_wed),
     /**
      * 木曜日
      */
-    THURSDAY(Calendar.THURSDAY, "4_thu", R.string.label_alarm_thu),
+    THURSDAY(DateTimeConstants.THURSDAY, "4_thu", R.string.label_alarm_thu),
     /**
      * 金曜日
      */
-    FRIDAY(Calendar.FRIDAY, "5_fri", R.string.label_alarm_fri),
+    FRIDAY(DateTimeConstants.FRIDAY, "5_fri", R.string.label_alarm_fri),
     /**
      * 土曜日
      */
-    SATURDAY(Calendar.SATURDAY, "6_sat", R.string.label_alarm_sat),
+    SATURDAY(DateTimeConstants.SATURDAY, "6_sat", R.string.label_alarm_sat),
     /**
      * 日曜日
      */
-    SUNDAY(Calendar.SUNDAY, "7_sun", R.string.label_alarm_sun);
+    SUNDAY(DateTimeConstants.SUNDAY, "7_sun", R.string.label_alarm_sun);
 
-    private final int days;
+    private final int constants;
     private final String key;
     private final int resId;
 
-    DayOfWeek(int days, String key, int resId) {
-        this.days = days;
+    DayOfWeek(int constants, String key, int resId) {
+        this.constants = constants;
         this.key = key;
         this.resId = resId;
     }
 
     /**
-     * 自身が表す曜日に応じた {@link Calendar} の情報を取得する。<br />
-     * {@link Calendar#set(int, int)} などで使用するための曜日情報。
+     * 自身が表す曜日に応じた {@link DateTimeConstants} の値を取得する。
      *
-     * @return 曜日を表す {@link Calendar} 用の値
+     * @return 曜日を表す {@link DateTimeConstants}
      */
-    public int getCalendarField() {
-        return days;
+    public int getConstants() {
+        return constants;
     }
 
     /**

--- a/app/src/main/java/com/team7/wakeuptaroapp/utils/TaroAlarmManager.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/utils/TaroAlarmManager.java
@@ -44,7 +44,7 @@ public class TaroAlarmManager {
      * @param alarm 登録対象のアラーム情報
      */
     public void register(@NonNull Alarm alarm) {
-        Preconditions.notNull(alarm, "Register alarm required!!");
+        Preconditions.notNull(alarm, "Register menu_alarm_register required!!");
 
         for (String dayOfWeek : alarm.getDayOfWeeks()) {
             DayOfWeek dow = DayOfWeek.resolve(dayOfWeek);
@@ -69,7 +69,7 @@ public class TaroAlarmManager {
      * @param alarm 取り消し対象のアラーム情報
      */
     public void cancel(@NonNull Alarm alarm) {
-        Preconditions.notNull(alarm, "Cancel alarm required!!");
+        Preconditions.notNull(alarm, "Cancel menu_alarm_register required!!");
 
         for (String dayOfWeek : alarm.getDayOfWeeks()) {
             DayOfWeek dow = DayOfWeek.resolve(dayOfWeek);
@@ -123,7 +123,7 @@ public class TaroAlarmManager {
      * @return アラーム時刻が既に過ぎている場合は true
      */
     private boolean isOverAlarmTime(Calendar now, Alarm alarm) {
-        String nowTime = String.format("%2d:%2d", now.get(Calendar.HOUR_OF_DAY), now.get(Calendar.MINUTE));
+        String nowTime = String.format("%02d:%02d", now.get(Calendar.HOUR_OF_DAY), now.get(Calendar.MINUTE));
         return (nowTime.compareTo(alarm.getTime()) > 0);
     }
 }

--- a/app/src/main/java/com/team7/wakeuptaroapp/utils/TaroAlarmManager.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/utils/TaroAlarmManager.java
@@ -9,10 +9,8 @@ import com.team7.wakeuptaroapp.models.Alarm;
 import com.team7.wakeuptaroapp.models.AlarmIntent;
 import com.team7.wakeuptaroapp.models.DayOfWeek;
 
-import org.apache.commons.lang3.time.DateUtils;
-
-import java.util.Calendar;
-import java.util.Locale;
+import org.joda.time.LocalDateTime;
+import org.joda.time.format.DateTimeFormat;
 
 import static android.app.AlarmManager.INTERVAL_DAY;
 
@@ -53,7 +51,7 @@ public class TaroAlarmManager {
             Long alarmTime = generateAlarmTime(alarm, dow);
 
             AlarmIntent intent = AlarmIntent.forService(context, alarm);
-            intent.setActionAsUniqueKey(alarm.getAlarmKey() + dow.getCalendarField()); // アラーム情報を重複させないよう識別させる
+            intent.setActionAsUniqueKey(alarm.getAlarmKey() + dow.getConstants()); // アラーム情報を重複させないよう識別させる
             intent.setAlarmKey(alarm.getAlarmKey());
             PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
@@ -75,7 +73,7 @@ public class TaroAlarmManager {
             DayOfWeek dow = DayOfWeek.resolve(dayOfWeek);
 
             AlarmIntent intent = AlarmIntent.forService(context, alarm);
-            intent.setActionAsUniqueKey(alarm.getAlarmKey() + dow.getCalendarField()); // アラーム情報を重複させないよう識別させる
+            intent.setActionAsUniqueKey(alarm.getAlarmKey() + dow.getConstants()); // アラーム情報を重複させないよう識別させる
             PendingIntent pendingIntent = PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
             // 同一 Action 値のアラームを全てキャンセル
@@ -97,21 +95,18 @@ public class TaroAlarmManager {
      */
     private Long generateAlarmTime(Alarm alarm, DayOfWeek dow) {
 
-        Calendar cal = Calendar.getInstance(Locale.JAPAN);
-        cal = DateUtils.truncate(cal, Calendar.MINUTE);
+        LocalDateTime dateTime = LocalDateTime.now().minuteOfHour().roundFloorCopy();
 
-        if (cal.get(Calendar.DAY_OF_WEEK) != dow.getCalendarField()) {
-            cal.set(Calendar.DAY_OF_WEEK, dow.getCalendarField());
-            cal.add(Calendar.DATE, 7);
-        } else if (isOverAlarmTime(cal, alarm)) {
-            cal.add(Calendar.DATE, 7);
+        if (dateTime.getDayOfWeek() != dow.getConstants()) {
+            dateTime = dateTime.withDayOfWeek(dow.getConstants());
+        } else if (isOverAlarmTime(dateTime, alarm)) {
+            dateTime = dateTime.plusWeeks(1);
         }
 
-        cal.set(Calendar.HOUR_OF_DAY, alarm.getTimeHour());
-        cal.set(Calendar.MINUTE, alarm.getTimeMinute());
+        dateTime = dateTime.withHourOfDay(alarm.getTimeHour()).withMinuteOfHour(alarm.getTimeMinute());
 
-        AppLog.d("AlarmTime(DOW): " + cal.toString() + "(" + dow.getResId() + ")");
-        return cal.getTimeInMillis();
+        AppLog.d("AlarmTime(DOW): " + dateTime.toString(DateTimeFormat.fullDateTime()) + "(" + dow.getResId() + ")");
+        return dateTime.toDateTime().getMillis();
     }
 
     /**
@@ -122,8 +117,8 @@ public class TaroAlarmManager {
      * @param alarm アラーム情報
      * @return アラーム時刻が既に過ぎている場合は true
      */
-    private boolean isOverAlarmTime(Calendar now, Alarm alarm) {
-        String nowTime = String.format("%02d:%02d", now.get(Calendar.HOUR_OF_DAY), now.get(Calendar.MINUTE));
-        return (nowTime.compareTo(alarm.getTime()) > 0);
+    private boolean isOverAlarmTime(LocalDateTime now, Alarm alarm) {
+        String nowTime = String.format("%02d:%02d", now.getHourOfDay(), now.getMinuteOfHour());
+        return (nowTime.compareTo(alarm.getTime()) >= 0);
     }
 }

--- a/app/src/main/java/com/team7/wakeuptaroapp/utils/TaroSharedPreference.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/utils/TaroSharedPreference.java
@@ -2,7 +2,7 @@ package com.team7.wakeuptaroapp.utils;
 
 import com.team7.wakeuptaroapp.models.Alarm;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import de.devland.esperandro.SharedPreferenceActions;
@@ -83,12 +83,12 @@ public interface TaroSharedPreference extends SharedPreferenceActions {
      *
      * @return アラーム一覧
      */
-    ArrayList<Alarm> alarms();
+    List<Alarm> alarms();
 
     /**
      * 登録済みのアラーム一覧を更新する。
      *
      * @param alarms アラーム一覧
      */
-    void alarms(ArrayList<Alarm> alarms);
+    void alarms(List<Alarm> alarms);
 }

--- a/app/src/main/java/com/team7/wakeuptaroapp/views/helpers/DayOfWeekHelper.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/views/helpers/DayOfWeekHelper.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 
 import com.team7.wakeuptaroapp.R;
 import com.team7.wakeuptaroapp.models.DayOfWeek;
-import com.team7.wakeuptaroapp.utils.Alarms;
 
 import org.apache.commons.lang3.ArrayUtils;
 

--- a/app/src/main/java/com/team7/wakeuptaroapp/views/preferences/AlarmDayOfWeekPreference.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/views/preferences/AlarmDayOfWeekPreference.java
@@ -1,6 +1,7 @@
 package com.team7.wakeuptaroapp.views.preferences;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.support.annotation.VisibleForTesting;
@@ -30,7 +31,8 @@ public class AlarmDayOfWeekPreference extends MultiSelectListPreference {
 
     @Override
     protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValue) {
-        setSummary(DayOfWeekHelper.convertToLabel(getContext()));
+        super.onSetInitialValue(restorePersistedValue, defaultValue);
+        setSummary(DayOfWeekHelper.convertToLabel(getContext(), getValues()));
     }
 
     @VisibleForTesting

--- a/app/src/main/java/com/team7/wakeuptaroapp/views/preferences/AlarmDayOfWeekPreference.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/views/preferences/AlarmDayOfWeekPreference.java
@@ -1,7 +1,6 @@
 package com.team7.wakeuptaroapp.views.preferences;
 
 import android.content.Context;
-import android.content.SharedPreferences;
 import android.preference.MultiSelectListPreference;
 import android.preference.Preference;
 import android.support.annotation.VisibleForTesting;

--- a/app/src/main/java/com/team7/wakeuptaroapp/views/preferences/AlarmRingtonePreference.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/views/preferences/AlarmRingtonePreference.java
@@ -55,9 +55,26 @@ public class AlarmRingtonePreference extends RingtonePreference {
         }
     }
 
+    /**
+     * 着信音のサマリー情報を制御する。<br />
+     * 指定された着信音の URI が null の場合、サイレントを設定する。
+     * それ以外の場合、対応する着信音のタイトルを設定する。
+     *
+     * @param ringtoneUri 着信音の URI
+     */
+    public void handleSummary(String ringtoneUri) {
+        if (TextUtils.isEmpty(ringtoneUri)) {
+            setAsSilentSummary();
+        } else {
+            Ringtone ringtone = RingtoneManager.getRingtone(getContext(), Uri.parse(ringtoneUri));
+            setAsRingtoneSummary(ringtone);
+        }
+    }
+
     @Override
     protected void onSetInitialValue(boolean restorePersistedValue, Object defaultValue) {
-        setAsSilentSummary();
+        String persisted = getPersistedString(null);
+        handleSummary(persisted);
     }
 
     @VisibleForTesting
@@ -67,16 +84,8 @@ public class AlarmRingtonePreference extends RingtonePreference {
         public boolean onPreferenceChange(Preference preference, Object newValue) {
 
             AlarmRingtonePreference pref = AlarmRingtonePreference.class.cast(preference);
-
             String ringtoneUri = newValue.toString();
-            if (TextUtils.isEmpty(ringtoneUri)) {
-                pref.setAsSilentSummary();
-
-            } else {
-                Ringtone ringtone = RingtoneManager.getRingtone(
-                        pref.getContext(), Uri.parse(ringtoneUri));
-                pref.setAsRingtoneSummary(ringtone);
-            }
+            pref.handleSummary(ringtoneUri);
 
             return true;
         }

--- a/app/src/main/res/layout/activity_alarm_list.xml
+++ b/app/src/main/res/layout/activity_alarm_list.xml
@@ -30,4 +30,17 @@
         app:borderWidth="0dp"
         app:fabSize="normal"
         />
+
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/edit_alarm"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentLeft="true"
+        android:onClick="onClickEditAlarm"
+        android:src="@drawable/plus"
+        app:backgroundTint="#5BD4D8"
+        app:borderWidth="0dp"
+        app:fabSize="normal"
+        />
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_start.xml
+++ b/app/src/main/res/layout/activity_start.xml
@@ -7,7 +7,8 @@
                 android:paddingLeft="@dimen/activity_horizontal_margin"
                 android:paddingRight="@dimen/activity_horizontal_margin"
                 android:paddingTop="@dimen/activity_vertical_margin"
-                tools:context=".activities.StartActivity">
+                tools:context=".activities.StartActivity"
+    >
 
     <TextView
         android:id="@+id/app_name"

--- a/app/src/main/res/menu/menu_alarm_register.xml
+++ b/app/src/main/res/menu/menu_alarm_register.xml
@@ -8,5 +8,6 @@
         android:id="@+id/action_store_alarm"
         android:orderInCategory="100"
         android:title="@string/action_store_alarm"
-        app:showAsAction="always"/>
+        app:showAsAction="always"
+        />
 </menu>

--- a/app/src/main/res/menu/menu_alarm_update.xml
+++ b/app/src/main/res/menu/menu_alarm_update.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto"
+      xmlns:tools="http://schemas.android.com/tools"
+      tools:context=".activities.AlarmActivity">
+
+    <item
+        android:id="@+id/action_update_alarm"
+        android:orderInCategory="100"
+        android:title="@string/action_update_alarm"
+        app:showAsAction="always"
+        />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,10 +6,12 @@
     <string name="start">Start</string>
     <string name="action_settings">設定</string>
     <string name="action_store_alarm">登録</string>
+    <string name="action_update_alarm">更新</string>
     <string name="stop_alarm">Stop!!</string>
 
     <string name="title_activity_alarm_list">アラーム一覧</string>
-    <string name="title_activity_alarm">アラーム登録</string>
+    <string name="title_activity_alarm_register">アラーム登録</string>
+    <string name="title_activity_alarm_update">アラーム更新</string>
     <string name="title_activity_setting">設定</string>
     <string name="title_dialog_disabled_bluetooth">Bluetooth 無効</string>
     <string name="title_dialog_ble_searching">起こしタロウ 親機 検索中</string>
@@ -20,6 +22,7 @@
     <string name="message_found_ble">起こしタロウ 親機 (%1$s) への接続に成功しました。</string>
     <string name="message_not_found_ble">起こしタロウ 親機が見つかりませんでした。</string>
     <string name="message_store_alarm">アラームを登録しました。</string>
+    <string name="message_update_alarm">アラームを更新しました。</string>
     <string name="message_notification">早く起きて!!</string>
     <string name="message_alarm">早く起きて!!\n親機まで急げ!!</string>
 
@@ -49,4 +52,6 @@
     <string name="label_alarm_weekday">平日</string>
     <string name="label_alarm_weekend">週末</string>
     <string name="label_alarm_silent">サイレント</string>
+
+    <string name="hello_world">Hello world!</string>
 </resources>

--- a/app/src/test/java/com/team7/wakeuptaroapp/models/AlarmTest.java
+++ b/app/src/test/java/com/team7/wakeuptaroapp/models/AlarmTest.java
@@ -1,11 +1,9 @@
 package com.team7.wakeuptaroapp.models;
 
-import org.apache.commons.lang3.time.DateUtils;
+import org.joda.time.LocalDateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.internal.util.reflection.Whitebox;
-
-import java.util.Calendar;
 
 import static com.team7.wakeuptaroapp.assertions.AlarmAssertion.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,16 +24,16 @@ public class AlarmTest {
 
     @Test
     public void 登録日時を基に_equals_の判定が行われること() {
-        Calendar now = Calendar.getInstance();
+        LocalDateTime now = LocalDateTime.now();
         Alarm other = new Alarm();
-        other.setRegisteredDateTime(DateUtils.addDays(now.getTime(), -1).getTime());
+        other.setRegisteredDateTime(now.minusDays(1).toDateTime().getMillis());
 
         // 事前検証
         assertThat(testee).isNotEqualTo(other);
 
         // 登録日時を上書き
-        Whitebox.setInternalState(testee, "registeredDateTime", now.getTimeInMillis());
-        Whitebox.setInternalState(other, "registeredDateTime", now.getTimeInMillis());
+        Whitebox.setInternalState(testee, "registeredDateTime", now.toDateTime().getMillis());
+        Whitebox.setInternalState(other, "registeredDateTime", now.toDateTime().getMillis());
 
         // 検証
         assertThat(testee).isEqualTo(other);
@@ -43,16 +41,16 @@ public class AlarmTest {
 
     @Test
     public void 登録日時を基に_compareTo_の判定が行われること() {
-        Calendar now = Calendar.getInstance();
+        LocalDateTime now = LocalDateTime.now();
         Alarm other = new Alarm();
-        other.setRegisteredDateTime(DateUtils.addDays(now.getTime(), -1).getTime());
+        other.setRegisteredDateTime(now.minusDays(1).toDateTime().getMillis());
 
         // 事前検証
         assertThat(testee.compareTo(other)).isNotEqualTo(0);
 
         // 登録日時を上書き
-        Whitebox.setInternalState(testee, "registeredDateTime", now.getTimeInMillis());
-        Whitebox.setInternalState(other, "registeredDateTime", now.getTimeInMillis());
+        Whitebox.setInternalState(testee, "registeredDateTime", now.toDateTime().getMillis());
+        Whitebox.setInternalState(other, "registeredDateTime", now.toDateTime().getMillis());
 
         // 検証
         assertThat(testee.compareTo(other)).isEqualTo(0);

--- a/app/src/test/java/com/team7/wakeuptaroapp/utils/TaroSharedPreferenceTest.java
+++ b/app/src/test/java/com/team7/wakeuptaroapp/utils/TaroSharedPreferenceTest.java
@@ -14,6 +14,7 @@ import org.robolectric.annotation.Config;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import de.devland.esperandro.Esperandro;
@@ -65,7 +66,7 @@ public class TaroSharedPreferenceTest {
 
     @Test
     public void アラーム情報一覧を取得保存できること() {
-        assertThat(testee.alarms()).isNull();
+        assertThat(testee.alarms()).isEmpty();
 
         // 空を保存
         testee.alarms(new ArrayList<Alarm>());
@@ -73,7 +74,7 @@ public class TaroSharedPreferenceTest {
 
         // アラーム 1 件保存
         Alarm alarm = newAlarm("08:00", "Ringtone1", "土", "日");
-        ArrayList<Alarm> alarms = testee.alarms();
+        List<Alarm> alarms = testee.alarms();
         alarms.add(alarm);
         testee.alarms(alarms);
 

--- a/app/src/test/java/com/team7/wakeuptaroapp/views/preferences/AlarmDayOfWeekPreferenceTest.java
+++ b/app/src/test/java/com/team7/wakeuptaroapp/views/preferences/AlarmDayOfWeekPreferenceTest.java
@@ -1,20 +1,31 @@
 package com.team7.wakeuptaroapp.views.preferences;
 
+import android.preference.PreferenceManager;
+
 import com.team7.wakeuptaroapp.BuildConfig;
 import com.team7.wakeuptaroapp.activities.AlarmRegisterActivity;
+import com.team7.wakeuptaroapp.utils.TaroSharedPreference;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.internal.util.reflection.Whitebox;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import de.devland.esperandro.Esperandro;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link AlarmDayOfWeekPreference}に対するテストクラス。
@@ -27,17 +38,19 @@ public class AlarmDayOfWeekPreferenceTest {
 
     private AlarmDayOfWeekPreference testee;
     private AlarmRegisterActivity activity;
+    private PreferenceManager preferenceMock;
 
     @Before
     public void setUp() {
         activity = Robolectric.setupActivity(AlarmRegisterActivity.class);
         testee = new AlarmDayOfWeekPreference(activity);
+        preferenceMock = mock(PreferenceManager.class);
     }
 
     @Test
     public void 初期状態のサマリー情報を取得できること() {
         // 実行
-        testee.onSetInitialValue(false, null);
+        testee.onSetInitialValue(true, null);
         // 検証
         assertThat(testee.getSummary()).isEqualTo("なし");
     }
@@ -49,5 +62,24 @@ public class AlarmDayOfWeekPreferenceTest {
         testee.listener.onPreferenceChange(testee, values);
         // 検証
         assertThat(testee.getSummary()).isEqualTo("月, 水");
+    }
+
+    @Test
+    public void 保存済みの内容でサマリー情報を取得できること() {
+        // 保存済みの情報をセット
+        TaroSharedPreference preference = Esperandro.getPreferences(TaroSharedPreference.class, RuntimeEnvironment.application);
+        preference.alarmDayOfWeeks(new HashSet<>(Arrays.asList("5_fri", "1_mon")));
+
+        // PreferenceManager の振る舞いを定義
+        when(preferenceMock.getSharedPreferences()).thenReturn(preference.get());
+        Whitebox.setInternalState(testee, "mPreferenceManager", preferenceMock);
+        testee.setKey("alarmDayOfWeeks");
+        testee.setPersistent(true);
+
+        // 実行
+        testee.onSetInitialValue(true, null);
+        // 検証
+        assertThat(testee.getSummary()).isEqualTo("月, 金");
+        verify(preferenceMock, times(2)).getSharedPreferences();
     }
 }

--- a/app/src/test/java/com/team7/wakeuptaroapp/views/preferences/AlarmDayOfWeekPreferenceTest.java
+++ b/app/src/test/java/com/team7/wakeuptaroapp/views/preferences/AlarmDayOfWeekPreferenceTest.java
@@ -1,7 +1,7 @@
 package com.team7.wakeuptaroapp.views.preferences;
 
 import com.team7.wakeuptaroapp.BuildConfig;
-import com.team7.wakeuptaroapp.activities.AlarmActivity;
+import com.team7.wakeuptaroapp.activities.AlarmRegisterActivity;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,11 +26,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AlarmDayOfWeekPreferenceTest {
 
     private AlarmDayOfWeekPreference testee;
-    private AlarmActivity activity;
+    private AlarmRegisterActivity activity;
 
     @Before
     public void setUp() {
-        activity = Robolectric.setupActivity(AlarmActivity.class);
+        activity = Robolectric.setupActivity(AlarmRegisterActivity.class);
         testee = new AlarmDayOfWeekPreference(activity);
     }
 

--- a/app/src/test/java/com/team7/wakeuptaroapp/views/preferences/AlarmRingtonePreferenceTest.java
+++ b/app/src/test/java/com/team7/wakeuptaroapp/views/preferences/AlarmRingtonePreferenceTest.java
@@ -3,7 +3,7 @@ package com.team7.wakeuptaroapp.views.preferences;
 import android.media.Ringtone;
 
 import com.team7.wakeuptaroapp.BuildConfig;
-import com.team7.wakeuptaroapp.activities.AlarmActivity;
+import com.team7.wakeuptaroapp.activities.AlarmRegisterActivity;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,11 +26,11 @@ import static org.mockito.Mockito.mock;
 public class AlarmRingtonePreferenceTest {
 
     private AlarmRingtonePreference testee;
-    private AlarmActivity activity;
+    private AlarmRegisterActivity activity;
 
     @Before
     public void setUp() {
-        activity = Robolectric.setupActivity(AlarmActivity.class);
+        activity = Robolectric.setupActivity(AlarmRegisterActivity.class);
         testee = new AlarmRingtonePreference(activity);
     }
 


### PR DESCRIPTION
アラームの更新画面を実装しました。
一覧画面との連携がまだなので、(更新画面へ遷移するための) 仮のボタンを一覧画面に配置しています。
※挙動的には、登録済みのアラーム一覧の 1 件目 (`alarms.get(0)`) のアラームを更新画面に表示しています。 
