### PR TITLE
アラーム情報の更新し忘れ対応

### DIFF
--- a/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivityTest.java
+++ b/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivityTest.java
@@ -34,6 +34,7 @@ import static com.team7.wakeuptaroapp.assertions.AlarmAssertion.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.Is.is;
 
 /**
@@ -157,7 +158,8 @@ public class AlarmUpdateActivityTest {
         onView(withText("OK")).perform(click());
 
         // 更新
-        onView(withContentDescription("上へ移動")).perform(click());
+        // CircleCI 環境依存に対応
+        onView(anyOf(withContentDescription("上へ移動"), withContentDescription("Navigate up"))).perform(click());
 
         // ダイアログを検証
         onView(withText("アラーム情報が変更されていますが、戻りますか?")).check(matches(isDisplayed()));

--- a/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivityTest.java
+++ b/app/src/androidTest/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivityTest.java
@@ -26,6 +26,7 @@ import static android.support.test.espresso.assertion.ViewAssertions.matches;
 import static android.support.test.espresso.matcher.PreferenceMatchers.withKey;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
 import static com.team7.wakeuptaroapp.activities.AlarmRegisterActivityTest.setTime;
@@ -34,8 +35,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.StringStartsWith.startsWith;
-import static org.hamcrest.object.HasToString.hasToString;
 
 /**
  * {@link AlarmUpdateActivity}に対するテストクラス。<br />
@@ -140,6 +139,28 @@ public class AlarmUpdateActivityTest {
 
         // エラーダイアログを検証
         onView(withText("アラームを鳴らす曜日を 1 つ以上選択してください。")).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void 値を変更して一覧画面へ戻ろうとした場合に確認ダイアログが表示されること() {
+        registerAlarm();
+
+        // 一覧画面へ戻る
+        onView(withClassName(is("AlarmListActivity")));
+
+        // 更新画面へ
+        onData(anything()).inAdapterView(withId(R.id.alarm_list)).atPosition(0).perform(click());
+
+        // 曜日の選択を解除
+        onData(withKey("alarmDayOfWeeks")).perform(click());
+        onView(withText("金")).perform(click());
+        onView(withText("OK")).perform(click());
+
+        // 更新
+        onView(withContentDescription("上へ移動")).perform(click());
+
+        // ダイアログを検証
+        onView(withText("アラーム情報が変更されていますが、戻りますか?")).check(matches(isDisplayed()));
     }
 
     private void registerAlarm() {

--- a/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivity.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmUpdateActivity.java
@@ -1,5 +1,7 @@
 package com.team7.wakeuptaroapp.activities;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -109,6 +111,27 @@ public class AlarmUpdateActivity extends AppCompatActivity {
         if (id == android.R.id.home) {
             AppLog.d("Tap to back on menu_alarm_update.");
 
+            if (isChanged()) {
+                new AlertDialog.Builder(this)
+                        .setTitle(R.string.title_dialog_alarm_validation_failure)
+                        .setMessage(R.string.message_alarm_changed_ignore)
+                        .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                runOnUiThread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        finish();
+                                    }
+                                });
+                            }
+                        })
+                        .setNegativeButton("Cancel", null)
+                        .create().show();
+
+                return true;
+            }
+
             finish();
             return true;
         }
@@ -145,6 +168,19 @@ public class AlarmUpdateActivity extends AppCompatActivity {
         // アラーム一覧画面の Activity を呼び出す。
         Intent intent = new Intent(AlarmUpdateActivity.this, AlarmListActivity.class);
         startActivity(intent);
+    }
+
+    /**
+     * 更新前のアラーム情報から変更があるかどうかを判定する。
+     *
+     * @return いずれかの項目で変更があった場合は true
+     */
+    private boolean isChanged() {
+        String newTime = preference.alarmTime();
+        Set<String> newDayOfWeeks = preference.alarmDayOfWeeks();
+        String newRingtoneUri = preference.alarmRingtone();
+
+        return targetAlarm.isChanged(newTime, newDayOfWeeks, newRingtoneUri);
     }
 
     /**

--- a/app/src/main/java/com/team7/wakeuptaroapp/models/Alarm.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/models/Alarm.java
@@ -1,6 +1,7 @@
 package com.team7.wakeuptaroapp.models;
 
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -175,6 +176,20 @@ public class Alarm implements Comparable<Alarm>, Serializable {
         if (dayOfWeeks.isEmpty()) {
             throw new AlarmConstraintViolationsException(R.string.message_day_of_week_not_selected);
         }
+    }
+
+    @JsonIgnore
+    public boolean isChanged(String newTime, Set<String> newDayOfWeeks, String newRingtoneUri) {
+        if (!TextUtils.equals(this.time, newTime)) {
+            return true;
+        }
+        if (!this.dayOfWeeks.equals(newDayOfWeeks)) {
+            return true;
+        }
+        if (!TextUtils.equals(this.ringtoneUri, newRingtoneUri)) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="title_dialog_ble_select">起こしタロウ 親機 選択</string>
     <string name="title_dialog_usated_device">起こしタロウ 親機 未設定</string>
     <string name="title_dialog_motion_waiting">起こしタロウ 親機 動作確認中</string>
-    <string name="title_dialog_alarm_validation_failure">アラーム登録失敗</string>
+    <string name="title_dialog_alarm_validation_failure">アラーム情報 確認</string>
 
     <string name="message_dialog_disabled_bluetooth">Bluetooth を有効にしてください。</string>
     <string name="message_dialog_ble_searching">起こしタロウ 親機を検索しています...</string>
@@ -37,6 +37,7 @@
     <string name="message_alarm">早く起きて!!\n親機まで急げ!!</string>
     <string name="message_alarm_stop_success">おはようございます!!</string>
     <string name="message_day_of_week_not_selected">アラームを鳴らす曜日を 1 つ以上選択してください。</string>
+    <string name="message_alarm_changed_ignore">アラーム情報が変更されていますが、戻りますか?</string>
 
     <!-- On Development Message -->
     <string name="message_alarm_delete_all">アラーム情報を全て削除しました。</string>

--- a/app/src/test/java/com/team7/wakeuptaroapp/models/AlarmTest.java
+++ b/app/src/test/java/com/team7/wakeuptaroapp/models/AlarmTest.java
@@ -1,9 +1,14 @@
 package com.team7.wakeuptaroapp.models;
 
+import com.team7.wakeuptaroapp.exceptions.AlarmConstraintViolationsException;
+
 import org.joda.time.LocalDateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.internal.util.reflection.Whitebox;
+
+import java.util.Arrays;
+import java.util.HashSet;
 
 import static com.team7.wakeuptaroapp.assertions.AlarmAssertion.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,5 +65,32 @@ public class AlarmTest {
     public void アラーム時刻の情報を取得できること() {
         testee.setTime("19:32");
         assertThat(testee).hasTimeHour(19).hasTimeMinute(32);
+    }
+
+    @Test(expected = AlarmConstraintViolationsException.class)
+    public void 曜日が未選択の場合に例外が送出されること() throws Exception {
+        testee.validate();
+    }
+
+    @Test
+    public void 曜日が1件でも選択されていた場合は例外が送出されないこと() throws Exception {
+        testee.setDayOfWeeks(new HashSet<String>(Arrays.asList("日")));
+        testee.validate();
+        // 何もおきないこと
+    }
+
+    @Test
+    public void 現在値から値の変更があった場合に_true_が返されること() {
+        // 変更無し
+        assertThat(testee.isChanged("", new HashSet<String>(), "")).isTrue();
+
+        // 時間
+        assertThat(testee.isChanged("12:34", new HashSet<String>(), "")).isTrue();
+
+        // 曜日
+        assertThat(testee.isChanged("", new HashSet<String>(Arrays.asList("月")), "")).isTrue();
+
+        // アラーム音
+        assertThat(testee.isChanged("", new HashSet<String>(), "HogeHoge")).isTrue();
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 version_code = 1
-version_name = 0.6.0
+version_name = 0.6.5
 
 notification_service_uuid=0000180f-0000-1000-8000-00805f9b34fb
 notification_characteristic_uuid=00002a1b-0000-1000-8000-00805f9b34fb


### PR DESCRIPTION
アラーム情報更新画面において、遷移時の情報から変更があったのに、戻るボタンで戻ろうとした場合に、エラーダイアログを表示する。
