### PR TITLE
親機設定が済んでいなくてもアラーム画面を表示できるよう対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,8 @@ android {
             // BSHSBTPT01BK (as Raspberry Pi)
             buildConfigField "String", "NOTIFICATION_SERVICE_UUID", "\"${project.property("notification_service_develop_uuid")}\""
             buildConfigField "String", "NOTIFICATION_CHARACTERISTIC_UUID", "\"${project.property("notification_characteristic_develop_uuid")}\""
+
+            buildConfigField "boolean", "APP_MODE_DEVELOP", "true"
         }
         production {
             applicationId PACKAGE_NAME
@@ -55,6 +57,8 @@ android {
             // Raspberry Pi
             buildConfigField "String", "NOTIFICATION_SERVICE_UUID", "\"${project.property("notification_service_uuid")}\""
             buildConfigField "String", "NOTIFICATION_CHARACTERISTIC_UUID", "\"${project.property("notification_characteristic_uuid")}\""
+
+            buildConfigField "boolean", "APP_MODE_DEVELOP", "false"
         }
     }
 

--- a/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmNotificationActivity.java
+++ b/app/src/main/java/com/team7/wakeuptaroapp/activities/AlarmNotificationActivity.java
@@ -21,6 +21,7 @@ import android.view.View;
 import android.view.WindowManager;
 
 import com.skyfishjy.library.RippleBackground;
+import com.team7.wakeuptaroapp.BuildConfig;
 import com.team7.wakeuptaroapp.R;
 import com.team7.wakeuptaroapp.ble.RaspberryPi;
 import com.team7.wakeuptaroapp.ble.RpiGattCallback;
@@ -235,12 +236,6 @@ public class AlarmNotificationActivity extends Activity {
             bluetoothDisabled = true;
             bluetoothAdapter.enable();
         }
-
-        // 接続検証済み親機の存在判定
-        if (TextUtils.isEmpty(preference.deviceName())) {
-            // TODO アラーム起動時に、接続検証済みの親機が居ない場合
-            return;
-        }
     }
 
     @Override
@@ -251,7 +246,9 @@ public class AlarmNotificationActivity extends Activity {
         // TODO もし親機との疎通に失敗した場合、緊急停止用として停止ボタンを活性化させる？
 
         // スキャン開始
-        startScan();
+        if (!TextUtils.isEmpty(preference.deviceName())) {
+            startScan();
+        }
     }
 
     @Override
@@ -360,7 +357,9 @@ public class AlarmNotificationActivity extends Activity {
      * @param view {@link View}
      */
     public void stopAlarmForce(View view) {
-        stopAlarm();
+        if (BuildConfig.APP_MODE_DEVELOP) {
+            stopAlarm();
+        }
     }
 
     @Override


### PR DESCRIPTION
ついでに、アラーム停止のオプション機能を develop flavor だけに制限
